### PR TITLE
Add NSPrivacyAccessedAPITypes to PrivacyInfo.xcprivacy

### DIFF
--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -29,5 +29,16 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>1C8F.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
### 🔗 Issue Links

[Jira ticket](https://whoopinc.atlassian.net/browse/IG-1356)

### 🎯 Goal

Starting in May, this would cause our app to be blocked by Apple without these privacy updates. 

### 📝 Summary

Updated PrivacyInfo.xcprivacy : 
- Added key `NSPrivacyAccessedAPITypes` for UserDefaults with reason [1C8F.1 ](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401)


